### PR TITLE
Detailed how to use twitter's built-in localization in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ ReactDOM.render((
     widgetId={'29838471883830183'}
     options={{
       username: 'TwitterDev',
-      height: '400'
+      height: '400',
+      lang: 'en'
     }}
     onLoad={() => console.log('Timeline is loaded!')}
   />
@@ -46,7 +47,9 @@ All widgets take an optional options object prop. To learn more about the availa
 
 `Tweet` requires a `tweetId` prop. Ex. `'511181794914627584'`
 
-All widgets accept an optional `onLoad` callback, which is called every time the widget is loaded/reloaded (both on inital load and updates).
+All widgets accept an optional `onLoad` callback, which is called every time the widget is loaded/reloaded (both on initial load and updates).
+
+Additional options such as localization and component dimensions can be found [on this page](https://dev.twitter.com/web/javascript/creating-widgets) under 'Options'.
 
 ## Contributing
 


### PR DESCRIPTION
    Instead of using 'data-lang' (as detailed on the standard html widgets [page](https://dev.twitter.com/web/overview/languages) ), we should merely use 'lang' as shown [here](https://dev.twitter.com/web/javascript/creating-widgets).

    Also added a link to the page containing the widget options for anyone looking for further customization.