### PR TITLE
Make this work in isomorphic react runtime setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
+    "exenv": "^1.2.1",
     "lodash.clonedeep": "^4.3.1",
     "lodash.isequal": "^4.1.1",
     "scriptjs": "^2.5.8"

--- a/src/components/AbstractWidget.js
+++ b/src/components/AbstractWidget.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import $script from 'scriptjs'
 
 export default class AbstractWidget extends React.Component {
   static propTypes = {
@@ -24,6 +23,7 @@ export default class AbstractWidget extends React.Component {
 
   loadWidget() {
     const { widgetWrapper } = this.refs
+    const $script = require('scriptjs')
 
     $script.ready('twitter-widgets', () => {
       // Delete existing

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
-import $script from 'scriptjs'
+import { canUseDOM } from 'exenv'
 
-$script('//platform.twitter.com/widgets.js', 'twitter-widgets')
+if (canUseDOM) {
+  const $script = require('scriptjs')
+  $script('//platform.twitter.com/widgets.js', 'twitter-widgets')
+}
 
 export Follow from './components/Follow'
 export Hashtag from './components/Hashtag'


### PR DESCRIPTION
scriptjs errors out when loaded on the server. Ensure that we only import it on the client via require, so that we can use twitter components in server-side isomorphic react.