### PR TITLE
make sure dataSource is also being deep cloned

### DIFF
--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -24,8 +24,8 @@ export default class Timeline extends React.Component {
   ready = (tw, element, done) => {
     const { dataSource, options, onLoad } = this.props
 
-    // Options must be cloned since Twitter Widgets modifies it directly
-    tw.widgets.createTimeline(dataSource, element, cloneDeep(options))
+    // Options and dataSource must be cloned since Twitter Widgets modifies it directly
+    tw.widgets.createTimeline(cloneDeep(dataSource), element, cloneDeep(options))
     .then(() => {
       // Widget is loaded
       done()


### PR DESCRIPTION
I noticed an issue where the Timeline widget was being incorrectly re-loaded every time my page state changed, namely when the `dataSource` and `options` of the Timeline widget had not changed. Turns out that Twitter modifies `dataSource` as well as `options`, so we have to `cloneDeep()` both to avoid the `shouldComponentUpdate()` function from returning `true` when it shouldn't.