### PR TITLE
Use raw lodash packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
   },
   "dependencies": {
     "exenv": "^1.2.1",
-    "lodash.clonedeep": "^4.3.1",
-    "lodash.isequal": "^4.1.1",
+    "lodash": "^4.17.4",
     "prop-types": "^15.3.0",
     "scriptjs": "^2.5.8"
   },

--- a/src/components/Follow.js
+++ b/src/components/Follow.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import isEqual from 'lodash.isequal'
-import cloneDeep from 'lodash.clonedeep'
-
+import isEqual from 'lodash/isEqual'
+import cloneDeep from 'lodash/cloneDeep'
 import AbstractWidget from './AbstractWidget'
 
 

--- a/src/components/Hashtag.js
+++ b/src/components/Hashtag.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import isEqual from 'lodash.isequal'
-import cloneDeep from 'lodash.clonedeep'
+import isEqual from 'lodash/isEqual'
+import cloneDeep from 'lodash/cloneDeep'
 import AbstractWidget from './AbstractWidget'
 
 export default class Hashtag extends React.Component {

--- a/src/components/Mention.js
+++ b/src/components/Mention.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import isEqual from 'lodash.isequal'
-import cloneDeep from 'lodash.clonedeep'
+import isEqual from 'lodash/isEqual'
+import cloneDeep from 'lodash/cloneDeep'
 import AbstractWidget from './AbstractWidget'
 
 export default class Mention extends React.Component {

--- a/src/components/Share.js
+++ b/src/components/Share.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import isEqual from 'lodash.isequal'
-import cloneDeep from 'lodash.clonedeep'
+import isEqual from 'lodash/isEqual'
+import cloneDeep from 'lodash/cloneDeep'
 import AbstractWidget from './AbstractWidget'
 
 export default class Share extends React.Component {

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import isEqual from 'lodash.isequal'
-import cloneDeep from 'lodash.clonedeep'
+import isEqual from 'lodash/isEqual'
+import cloneDeep from 'lodash/cloneDeep'
 import AbstractWidget from './AbstractWidget'
 
 export default class Timeline extends React.Component {

--- a/src/components/Tweet.js
+++ b/src/components/Tweet.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import isEqual from 'lodash.isequal'
-import cloneDeep from 'lodash.clonedeep'
+import isEqual from 'lodash/isEqual'
+import cloneDeep from 'lodash/cloneDeep'
 import AbstractWidget from './AbstractWidget'
 
 export default class Tweet extends React.Component {


### PR DESCRIPTION
This allows greater module reuse when shared in a larger webpack build.