### PR TITLE
Use https scheme for cordova

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { canUseDOM } from 'exenv'
 
 if (canUseDOM) {
   const $script = require('scriptjs') // eslint-disable-line global-require
-  $script('//platform.twitter.com/widgets.js', 'twitter-widgets')
+  $script('https//platform.twitter.com/widgets.js', 'twitter-widgets')
 }
 
 export Follow from './components/Follow'


### PR DESCRIPTION
Hi.Thank you for the great widgets.

I am developing the native app with React + Redux + Cordova and using this widget for Twitter timeline.
I've faced a problem when I checking the app in actual devise because it's not showing the timeline.
The problem is Cordova doesn't recognize the URI scheme in devise so I've added the scheme and it worked.
It'll be very useful to add the uri scheme to work this widget in non-browser app.

Thank you.
