### PR TITLE
Ensure async JS is completely loaded/executed

### DIFF
--- a/src/components/AbstractWidget.js
+++ b/src/components/AbstractWidget.js
@@ -42,7 +42,8 @@ export default class AbstractWidget extends React.Component {
     const $script = require('scriptjs') // eslint-disable-line global-require
 
     $script.ready('twitter-widgets', () => {
-      if (!window.twttr) {
+      const tw = window.twttr;
+      if (!tw || !tw.widgets) {
         // If the script tag fails to load, scriptjs.ready() will still trigger.
         // Let's avoid the JS exceptions when that happens.
         console.error('Failure to load window.twttr, aborting load.') // eslint-disable-line no-console
@@ -53,7 +54,7 @@ export default class AbstractWidget extends React.Component {
       AbstractWidget.removeChildren(this.widgetWrapper)
 
       // Create widget
-      this.props.ready(window.twttr, this.widgetWrapper, this.done)
+      this.props.ready(tw, this.widgetWrapper, this.done)
     })
   }
 


### PR DESCRIPTION
Background
----------------
I use an ad-blocker which partially blocks third party twitter requests on sites until I whitelist them. Obviously, this breaks the widgets, which is fine, however an exception is currently being thrown which happened to break the whole page I was trying to visit (until I unblocked Twitter completely). Worse, it doesn't appear that there is any easy way for a host application to guard against this with a try-catch as this exception is thrown on import.

The exception I was getting is:

```
TypeError: Cannot read property 'createFollowButton' of undefined
```

Changes
-------------
 - Modified `AbstractWidget` to ensure that `window.twttr.widgets` is defined, rather than only checking `window.twttr`.