### PR TITLE
Avoid features that require babel helpers (async/await, spread)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ function useTwitterWidget(factoryFunctionName, primaryArg, options, onLoad) {
     if (ref.current) {
       removeChildrenWithAttribute(ref.current, childDivIdentifyingAttribute);
 
-      async function loadWidget() {
+      function loadWidget() {
         if (!ref || !ref.current) {
           return;
         }
@@ -59,19 +59,17 @@ function useTwitterWidget(factoryFunctionName, primaryArg, options, onLoad) {
         childEl.setAttribute(childDivIdentifyingAttribute, "yes");
         ref.current.appendChild(childEl);
 
-        try {
-          const wf = await twWidgetFactory();
-
+        twWidgetFactory().then((wf) => {
           // primaryArg (possibly an object) and options must be cloned
           // since twitter mutates them (gah!).
           // There currently aren't any nested arrays or objects, so they
           // can be cloned in a shallow manner.
-          const resultMaybe = await wf[factoryFunctionName](
+          return wf[factoryFunctionName](
             cloneShallow(primaryArg),
             childEl,
             cloneShallow(options)
           );
-
+        }).then((resultMaybe) => {
           // Twitter returns undefined if widget creation fails.
           // However, if deps are stale (isCanceled), suppress error (likely race condition).
           if (!resultMaybe && !isCanceled) {
@@ -80,26 +78,26 @@ function useTwitterWidget(factoryFunctionName, primaryArg, options, onLoad) {
                 "Tweet, ensure the screenName/tweetId exists."
             );
           }
-        } catch (e) {
+
+          if (!ref || !ref.current) {
+            return;
+          }
+
+          if (isCanceled) {
+            if (childEl) {
+              childEl.remove();
+            }
+            return;
+          }
+
+          if (onLoad) {
+            onLoad();
+          }
+        })
+        .catch((e) => {
           console.error(e);
           setError(e);
-          return;
-        }
-
-        if (!ref || !ref.current) {
-          return;
-        }
-
-        if (isCanceled) {
-          if (childEl) {
-            childEl.remove();
-          }
-          return;
-        }
-
-        if (onLoad) {
-          onLoad();
-        }
+        });
       }
 
       loadWidget();

--- a/src/utils.js
+++ b/src/utils.js
@@ -92,5 +92,5 @@ export function useShallowCompareMemoize(value) {
 }
 
 export function cloneShallow(value) {
-  return typeof value === "object" ? { ...value } : value;
+  return typeof value === "object" ? Object.assign({}, value) : value;
 }


### PR DESCRIPTION
Unfortunately, using features such as async/await and object spread require the inclusion of helpers from Babel (including regenerator), which bloat the overall bundle size. By rewriting without those, the bundle size is reduced by about 50%.

Alternately, the babel config for this project could be adjusted to not transform async/await or object spread, which are widely supported by modern browsers, but that would make this library unusable without further transformation on older browsers.