### PR TITLE
Add React 18 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^16.13.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17"
+    "react": "^16.8.0 || ^17 || ^18"
   },
   "scripts": {
     "build": "nwb build-react-component",


### PR DESCRIPTION
Very minor housekeeping - this includes the recent React 18 version as an acceptable peer dependency.