### PR TITLE
Lazy load twitter scripts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,11 @@
 import React, { useRef, useEffect, useState } from "react";
 import {
   canUseDOM,
-  twLoad,
   useShallowCompareMemoize,
   removeChildrenWithAttribute,
   twWidgetFactory,
   cloneShallow
 } from "./utils";
-
-if (canUseDOM) {
-  twLoad();
-}
 
 const childDivIdentifyingAttribute = "twdiv";
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,14 +11,15 @@ export const canUseDOM = !!(
   window.document.createElement
 );
 
-export function twLoad() {
-  loadjs(twScriptUrl, twScriptName);
-}
-
 export function twWidgetFactory() {
   return new Promise((resolve, reject) => {
     const rejectWithError = () =>
       reject(new Error("Could not load remote twitter widgets js"));
+
+    if (!loadjs.isDefined(twScriptName)) {
+      loadjs(twScriptUrl, twScriptName);
+    }
+
     loadjs.ready(twScriptName, {
       success: () => {
         // Ensure loaded


### PR DESCRIPTION
This defers loading the Twitter scripts until one of the components is rendered. My use case is that I would like to conditionally render a Twitter component, but as the library is today the Twitter scripts will be loaded as soon as the module containing my component is resolved. I'd rather have the scripts injected only when I intend to show the component.